### PR TITLE
fix: index.md description (stale indices/ reference)

### DIFF
--- a/knowledge-docs/index.md
+++ b/knowledge-docs/index.md
@@ -1,8 +1,8 @@
 # Tres Finance Knowledge Docs
 
 > LLM-navigable knowledge corpus for the Tres Finance platform. This is the
-> master index (llms.txt format); per-source indices sit beside this file in
-> indices/, and every linked article is a markdown file in this directory tree.
+> index of every article in this directory tree (public content only —
+> customer Q&A lives in the private internal-docs repo).
 
 ## product-docs
 


### PR DESCRIPTION
The description block still referenced the removed per-source `indices/` folder and llms.txt naming. 3-line wording fix; no entries changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)