### PR TITLE
ci(help-center): run sync on GitHub-hosted ubuntu-latest

### DIFF
--- a/.github/workflows/sync-help-center.yml
+++ b/.github/workflows/sync-help-center.yml
@@ -15,11 +15,11 @@ concurrency:
 
 jobs:
   sync:
-    # Tres self-hosted runner: Tres-Finance has an org IP allow list, so the
-    # PAT-authenticated PR/auto-merge calls must originate from an allow-listed
-    # IP. Only maintainers trigger this (schedule/dispatch), so there is no
-    # untrusted-fork-PR code-execution risk from using a self-hosted runner.
-    runs-on: default-runners-ubuntu22.04-arm64
+    # GitHub-hosted runner: self-hosted runners are disallowed on this public
+    # repo (an untrusted fork PR could execute code on internal infra). The
+    # PAT push/PR/auto-merge calls must therefore be reachable from
+    # GitHub-hosted IPs under the org IP allow list.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:


### PR DESCRIPTION
Switches the `help-center` sync job from the self-hosted runner to GitHub-hosted `ubuntu-latest`.

## Why
Per org security: self-hosted runners are disallowed on this **public** repo — an untrusted fork PR could execute code on internal infra. The sync is maintainer-triggered only, but the safe fix is to run it on a GitHub-hosted runner.

## Note on the IP allow list
The self-hosted runner previously also ensured the PAT push/PR/auto-merge originated from an allow-listed IP. On `ubuntu-latest` those calls come from GitHub-hosted IPs, which must be reachable under the org IP allow list. To be validated with a real (article-changing) sync, not just a no-op.

## Scope
Single line change in `.github/workflows/sync-help-center.yml` (`runs-on`) + comment. The gate workflow `knowledge-docs-checks.yml` was already `ubuntu-latest`.