### PR TITLE
test(help-center): stale one anchor entry to force a sync change

### DIFF
--- a/knowledge-docs/help-center/.sync-state.json
+++ b/knowledge-docs/help-center/.sync-state.json
@@ -1,7 +1,7 @@
 {
   "articles": {
     "1099-form-generation": {
-      "lastmod": "2026-04-21T13:57:51.862Z",
+      "lastmod": "2020-01-01T00:00:00.000Z",
       "url": "https://help.tres.finance/article/1099-form-generation"
     },
     "accounting-methodologies-in-tres-finance": {


### PR DESCRIPTION
**Validation PR (setup step).** Stales the `1099-form-generation` anchor `lastmod` so the next `Sync help-center` run detects it as changed and opens a real sync PR — validating the PAT push/PR/auto-merge path from GitHub-hosted `ubuntu-latest` under the org IP allow list.

Single-line change to `.sync-state.json` (allowed by the md-only gate).