### PR TITLE
test(help-center): revert staled anchor (forced-test cleanup)

### DIFF
--- a/knowledge-docs/help-center/.sync-state.json
+++ b/knowledge-docs/help-center/.sync-state.json
@@ -1,7 +1,7 @@
 {
   "articles": {
     "1099-form-generation": {
-      "lastmod": "2020-01-01T00:00:00.000Z",
+      "lastmod": "2026-04-21T13:57:51.862Z",
       "url": "https://help.tres.finance/article/1099-form-generation"
     },
     "accounting-methodologies-in-tres-finance": {


### PR DESCRIPTION
Restores the real 1099-form-generation lastmod after the forced single-article validation, so scheduled syncs stop detecting a phantom change. One-line .sync-state.json revert.